### PR TITLE
OIDC Session decoding fails when OIDCSessionType client-cookie

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+04/13/2023
+- fix OIDC Session decoding fails when OIDCSessionType client-cookie
+
 04/11/2023
 - add caching of signed userinfo JWTs; default cache time is set to the "exp" claim, can be configured/disabled with:
     SetEnvIfExpr true "OIDC_USERINFO_SIGNED_JWT_CACHE_TTL=0" 

--- a/src/jose.c
+++ b/src/jose.c
@@ -914,6 +914,7 @@ static apr_byte_t oidc_jose_zlib_compress(apr_pool_t *pool, const char *input,
 	return TRUE;
 }
 
+#define OIDC_CJOSE_UNCOMPRESS_CHUNK 8192
 static apr_byte_t oidc_jose_zlib_uncompress(apr_pool_t *pool, const char *input,
 		int input_len, char **output, int *output_len, oidc_jose_error_t *err) {
 	z_stream zlib;
@@ -922,21 +923,51 @@ static apr_byte_t oidc_jose_zlib_uncompress(apr_pool_t *pool, const char *input,
 	zlib.opaque = Z_NULL;
 	zlib.avail_in = (uInt) input_len;
 	zlib.next_in = (Bytef*) input;
-	*output = apr_pcalloc(pool, input_len * 4);
-	zlib.avail_out = (uInt) (input_len * 4);
-	zlib.next_out = (Bytef*) (*output);
-
-	inflateInit(&zlib);
-	if (inflate(&zlib, Z_FINISH) != Z_STREAM_END) {
-		oidc_jose_error(err, "inflate failed");
+	zlib.total_out = 0;
+	size_t uncompLength = OIDC_CJOSE_UNCOMPRESS_CHUNK;
+	char *uncomp = (char *) calloc(sizeof (char), uncompLength);
+	if (uncomp == NULL) {
+		oidc_jose_error(err, "memory allocation error");
 		return FALSE;
 	}
+
+	inflateInit(&zlib);
+	int done = 1;
+	while (done) {
+		int inflate_status;
+		if (zlib.total_out >= OIDC_CJOSE_UNCOMPRESS_CHUNK) {
+			char *uncomp2 = (char *) calloc(sizeof (char), uncompLength + OIDC_CJOSE_UNCOMPRESS_CHUNK);
+			if (uncomp2 == NULL) {
+				free(uncomp);
+				oidc_jose_error(err, "memory allocation error");
+				return FALSE;
+			}
+			_oidc_memcpy(uncomp2, uncomp, uncompLength);
+			uncompLength += OIDC_CJOSE_UNCOMPRESS_CHUNK;
+			free(uncomp);
+			uncomp = uncomp2;
+		}
+		zlib.next_out = (Bytef *) (uncomp + zlib.total_out);
+		zlib.avail_out = (uInt) uncompLength - zlib.total_out;
+		inflate_status = inflate(&zlib, Z_SYNC_FLUSH);
+		if (inflate_status == Z_STREAM_END) {
+			done = 0;
+		} else if (inflate_status != Z_OK) {
+			oidc_jose_error(err, "inflate failed. ret:[%d]", inflate_status);
+			free(uncomp);
+			return FALSE;
+		}
+	}
+
 	if (inflateEnd(&zlib) != Z_OK) {
 		oidc_jose_error(err, "inflateEnd failed");
+		free(uncomp);
 		return FALSE;
 	}
 
 	*output_len = (int) zlib.total_out;
+	*output = (char *)apr_pstrdup(pool, uncomp);
+	free(uncomp);
 
 	return TRUE;
 }

--- a/src/jose.c
+++ b/src/jose.c
@@ -925,7 +925,7 @@ static apr_byte_t oidc_jose_zlib_uncompress(apr_pool_t *pool, const char *input,
 	zlib.next_in = (Bytef*) input;
 	zlib.total_out = 0;
 	size_t uncompLength = OIDC_CJOSE_UNCOMPRESS_CHUNK;
-	char *uncomp = (char *) calloc(sizeof (char), uncompLength);
+	char *uncomp = (char *) calloc(sizeof (char), uncompLength + 1);
 	if (uncomp == NULL) {
 		oidc_jose_error(err, "memory allocation error");
 		return FALSE;


### PR DESCRIPTION
Update zlib handling of uncompress.
 Fix a buffer error(Z_BUF_ERROR) when uncompressing highly compressed data due to small buffer size.