### PR TITLE
Add option to not pass access_token to application

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,7 @@
 07/12/2023
+- add support for hiding access_token from header/environment with OIDCPassAccessToken config option
+
+07/12/2023
 - add a sanity alg/enc check on self-encrypted AES GCM JWTs
 - bump to 2.4.14.3rc0
 

--- a/auth_openidc.conf
+++ b/auth_openidc.conf
@@ -950,6 +950,11 @@
 # The default is "Off" (for security reasons). Can be configured on a per Directory/Location basis.
 #OIDCPreservePost [On|Off]
 
+# Indicates whether the access token and access token expires will be passed to the application in a header/environment variable, according
+# to the OIDCPassClaimsAs directive.
+# Can be configured on a per Directory/Location basis. The default is "On".
+#OIDCPassAccessToken [On|Off]
+#
 # Indicates whether the refresh token will be passed to the application in a header/environment variable, according
 # to the OIDCPassClaimsAs directive.
 # Can be configured on a per Directory/Location basis. The default is "Off". 

--- a/src/mod_auth_openidc.c
+++ b/src/mod_auth_openidc.c
@@ -1308,7 +1308,7 @@ static apr_byte_t oidc_session_pass_tokens(request_rec *r, oidc_cfg *cfg,
 
 	/* set the access_token in the app headers/variables */
 	const char *access_token = oidc_session_get_access_token(r, session);
-	if (access_token != NULL) {
+	if ((oidc_cfg_dir_pass_access_token(r) != 0) && access_token != NULL) {
 		/* pass it to the app in a header or environment variable */
 		oidc_util_set_app_info(r, OIDC_APP_INFO_ACCESS_TOKEN, access_token,
 				OIDC_DEFAULT_HEADER_PREFIX, pass_headers, pass_envvars, pass_hdr_as);
@@ -1317,7 +1317,7 @@ static apr_byte_t oidc_session_pass_tokens(request_rec *r, oidc_cfg *cfg,
 	/* set the expiry timestamp in the app headers/variables */
 	const char *access_token_expires = oidc_session_get_access_token_expires(r,
 			session);
-	if (access_token_expires != NULL) {
+	if ((oidc_cfg_dir_pass_access_token(r) != 0) && access_token_expires != NULL) {
 		/* pass it to the app in a header or environment variable */
 		oidc_util_set_app_info(r, OIDC_APP_INFO_ACCESS_TOKEN_EXP,
 				access_token_expires,

--- a/src/mod_auth_openidc.h
+++ b/src/mod_auth_openidc.h
@@ -782,6 +782,7 @@ apr_byte_t oidc_cfg_dir_pass_info_in_headers(request_rec *r);
 apr_byte_t oidc_cfg_dir_pass_info_in_envvars(request_rec *r);
 int oidc_cfg_dir_pass_info_encoding(request_rec *r);
 apr_byte_t oidc_cfg_dir_pass_refresh_token(request_rec *r);
+apr_byte_t oidc_cfg_dir_pass_access_token(request_rec *r);
 apr_byte_t oidc_cfg_dir_accept_token_in(request_rec *r);
 char *oidc_cfg_dir_accept_token_in_option(request_rec *r, const char *key);
 int oidc_cfg_token_introspection_interval(request_rec *r);


### PR DESCRIPTION
Adds OIDCPassAccessToken config option to control if the OIDC_access_token and OIDC_access_token_expires variables should be exposed to the client application.