### PR TITLE
Use `apr_file_rename()` in `oidc_cache_file_set()` for compatiblity on windows

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -90,4 +90,5 @@ reporting bugs, providing fixes, suggesting useful features or other:
 	Mads Freek Petersen <https://github.com/madsfreek>
 	Stefan Richter <https://github.com/sealor>
 	Mattias Åsander <https://github.com/mattias-asander>
+	adg-mh <https://github.com/adg-mh>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+01/17/2024
+- use `apr_file_rename` in file backend to fix issue with renaming files on windows
+
 01/09/2024
 - release 2.4.15
 

--- a/src/cache/file.c
+++ b/src/cache/file.c
@@ -408,7 +408,7 @@ static apr_byte_t oidc_cache_file_set(request_rec *r, const char *section, const
 	apr_file_unlock(fd);
 	apr_file_close(fd);
 
-	if (rename(path, target) != 0) {
+	if ((rc = apr_file_rename(path, target, r->pool)) != APR_SUCCESS) {
 		oidc_error(r, "cache file: %s could not be renamed to: %s", path, target);
 		return FALSE;
 	}


### PR DESCRIPTION
Under msvc, rename() fails if the target file already exists, causing errors when using the file backend.

- `apr_file_rename()` uses MoveFileEx() on windows passing the flags to overwrite if the destination exists.
- `apr_file_rename()` still uses `rename()` on *nix.

