### PR TITLE
Unautz action expr parsing

### DIFF
--- a/auth_openidc.conf
+++ b/auth_openidc.conf
@@ -945,11 +945,33 @@
 # "401" return HTTP 401 Unauthorized with optional text message if specified in <argument>
 # "403" return HTTP 403 Forbidden with optional text message; NB: for Apache 2.4 this is controlled by the AuthzSendForbiddenOnFailure directive!
 # "302" redirect to the URL specified in the <argument> parameter
-# "auth" redirect the user to the OpenID Connect Provider or Discovery page for authentication (<argument> is unused)
+# "auth" redirect the user to the OpenID Connect Provider or Discovery page for authentication (See below for <agument> usage)
 # Useful in Location/Directory/Proxy path contexts that need to do stepup authentication
 # Be aware that this will only work in combination with a single Require statement or RequireAll,
 # so using RequireAny and multiple Require statements is not supported.
 # When not defined the default "403" is used. However Apache 2.4 will change this to 401 unless you set "AuthzSendForbiddenOnFailure on"
+#
+# Only for Apache >= 2.4.x:
+# Since verson 2.4.4 a boolean Apache expression as the second parameter to "auth" to specify which requests
+# need to match to allow for authentication.
+# See also: https://httpd.apache.org/docs/2.4/expr.html.
+# Requests that don't match the expression will return the default "403".
+# E.g to effectively override the default XML request detection algorithm by ignoring the Sec-Fetch-Mode,
+# Sec-Fetch-Dest and Accept headers:
+#   OIDCUnAutzAction auth "%{HTTP:X-Requested-With} == 'XMLHttpRequest'"
+# to return auth for all user agents that do not send an Accept header that includes a "text/html" value:
+#   OIDCUnAutzAction auth "%{HTTP_ACCEPT} !~ m#text/html#"
+# or as a more complex example, which equals the default XML request detection algorithm:
+#   OIDCUnAutzAction auth "%{HTTP:X-Requested-With} == 'XMLHttpRequest' \
+#                     || ( -n %{HTTP:Sec-Fetch-Mode} && %{HTTP:Sec-Fetch-Mode} != 'navigate' ) \
+#                     || ( -n %{HTTP:Sec-Fetch-Dest} && %{HTTP:Sec-Fetch-Dest} != 'document' ) \
+#                     || (    ( %{HTTP_ACCEPT} !~ m#text/html# ) \
+#                          && ( %{HTTP_ACCEPT} !~ m#application/xhtml\+xml# ) \
+#                          && ( %{HTTP_ACCEPT} !~ m#\*/\*# ) )"
+# To enable authorization in an iframe you need to change the Sec-Fetch-Dest part above in:
+#                     || ( -n %{HTTP:Sec-Fetch-Dest} && %{HTTP:Sec-Fetch-Dest} != 'iframe' && %{HTTP:Sec-Fetch-Dest} != 'document') \
+# To disable auto-detection of XML HTTP request altogether and uncondtionally return "auth" for all clients:
+#   OIDCUnAuthAction auth true
 #OIDCUnAutzAction [401|403|302|auth] [<argument>]
 
 # Indicates whether POST data will be preserved across authentication requests (and discovery in case of multiple OPs).

--- a/src/handle/authz.c
+++ b/src/handle/authz.c
@@ -495,7 +495,8 @@ static authz_status oidc_authz_24_unauthorized_user(request_rec *r) {
 		 * complete an authentication round trip to the provider, we
 		 * won't redirect the user and thus avoid creating a state cookie
 		 */
-		if (oidc_is_auth_capable_request(r) == FALSE) {
+		 if ((oidc_dir_cfg_unautz_expr_is_set(r) == FALSE)
+				&& (oidc_is_auth_capable_request(r) == FALSE)) {
 			OIDC_METRICS_COUNTER_INC(r, c, OM_AUTHZ_ACTION_401);
 			return AUTHZ_DENIED;
 		}

--- a/src/mod_auth_openidc.h
+++ b/src/mod_auth_openidc.h
@@ -796,6 +796,7 @@ apr_array_header_t *oidc_dir_cfg_pass_cookies(request_rec *r);
 apr_array_header_t *oidc_dir_cfg_strip_cookies(request_rec *r);
 int oidc_dir_cfg_unauth_action(request_rec *r);
 apr_byte_t oidc_dir_cfg_unauth_expr_is_set(request_rec *r);
+apr_byte_t oidc_dir_cfg_unautz_expr_is_set(request_rec *r);
 int oidc_dir_cfg_unautz_action(request_rec *r);
 char *oidc_dir_cfg_unauthz_arg(request_rec *r);
 const char *oidc_dir_cfg_path_auth_request_params(request_rec *r);


### PR DESCRIPTION
I've raised this because I've had issues at my work with two different scenarios. Some old legacy systems had need for processing unauthenticated users within an iframe and users with specific versions of safari were failing the default check due to compatibility issues with sec-fetch headers. 

I've added the custom expression parsing that already exists on `OIDCUnAuthAction` to `OIDCUnAutzAction` when the action is `auth`. The expression overrides the default but behaves in the same way, if the expression passes then the user can be redirected to the OpenID Connect Provider. If the expression fails it behaves the same way that the existing default expression check fails.
