### PR TITLE
Avoid mixing error content when preserving POST data has a claim condition

### DIFF
--- a/src/handle/authz.c
+++ b/src/handle/authz.c
@@ -554,6 +554,10 @@ authz_status oidc_authz_24_checker(request_rec *r, const char *require_args, con
 			return AUTHZ_GRANTED;
 		if (r->method_number == M_OPTIONS)
 			return AUTHZ_GRANTED;
+		/* avoid mixing error content when preserving POST data has a claim condition */
+		if ((r->method_number == M_POST) && (oidc_cfg_dir_preserve_post_get(r) == 1)) {
+			return AUTHZ_GRANTED;
+		}
 	}
 
 	/* get the set of claims from the request state (they've been set in the authentication part earlier */


### PR DESCRIPTION
This pull request is a fix for a problem with mixed error content when the POST data save function has a CLAIM condition in its path.

I have discussed this at the following URL
https://github.com/OpenIDC/mod_auth_openidc/discussions/1173

This will resolve the mixed error content.
Can you please confirm the fix?
