### PR TITLE
Update docs that DPoP requires a private signing key

### DIFF
--- a/auth_openidc.conf
+++ b/auth_openidc.conf
@@ -314,6 +314,7 @@
 #  optional: a DPoP token is requested from the OP but we'll continue even if the returned token is Bearer
 #  required: a DPoP token is requested from the OP and we'll fail if the returned token type is not DPoP
 # When not defined "off" is used.
+# To be able to request a DPoP token, OIDCPrivateKeyFiles/OIDCPublicKeyFiles settings require a RSA/EC private signing key.
 # NB: this can be overridden on a per-OP basis in the .conf file using the key: dpop_mode
 # The 2nd parameter is used to optionally enable an API for creating DPoP proofs on:
 #   <redirect_uri>?dpop=<access_token>&url=<url>[&method=<method][&nonce=<nonce>]


### PR DESCRIPTION
This is a suggestion to update the docs. Feel free to update as needed, or discard if you think you'd rather have the runtime check only in a2b1e662721757802a07c3797c3b40e389c42d1b

Closes #1293