### PR TITLE
metrics: avoid possible segfault after restart twice

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -95,3 +95,4 @@ reporting bugs, providing fixes, suggesting useful features or other:
 	ryanwilliamnicholls <https://github.com/ryanwilliamnicholls>
 	Dmitrii Ermakov <https://github.com/ErmakovDmitriy>
 	tarteens <https://github.com/tarteens>
+	Atzm WATANABE <https://github.com/atzm>

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+05/23/2025
+- metrics: avoid possible segfault after restart twice
+
 05/17/2025
 - code: refactor util.c into util/ directory
 

--- a/src/metrics.c
+++ b/src/metrics.c
@@ -879,6 +879,7 @@ apr_status_t oidc_metrics_cleanup(server_rec *s) {
 	apr_thread_join(&rv, _oidc_metrics_thread);
 	if (rv != APR_SUCCESS)
 		oidc_serror(s, "apr_thread_join failed");
+	_oidc_metrics_thread_exit = FALSE;
 	_oidc_metrics_thread = NULL;
 
 	/* delete the shared memory segment if we are in the parent process */


### PR DESCRIPTION
Accessing the metrics endpoint after restarting apache twice (using apachectl restart) can result in a segfault due to internal state corruption, especially when using prefork mpm.

```
[Thu May 22 15:20:51.875701 2025] [core:notice] [pid 9258:tid 9258] AH00051: child pid 9297 exit signal Segmentation fault (11), possible coredump in /usr/local/apache2
```

```
#0  0x00007f0dab976e33 in _oidc_metrics_storage_get (s=0x7f0daaf1f100) at src/metrics.c:339
#1  oidc_metrics_handle_request (r=0x7f0d96bd50b0) at src/metrics.c:1585
#2  0x00007f0dab953878 in oidc_content_handler (r=0x7f0d96bd50b0) at src/handle/content.c:60
#3  0x0000558faf66b0bb in ap_run_handler ()
#4  0x0000558faf66bc1b in ap_invoke_handler ()
#5  0x0000558faf68defb in ap_process_async_request ()
#6  0x0000558faf68dfc7 in ap_process_request ()
#7  0x0000558faf689484 in ap_process_http_sync_connection ()
#8  0x0000558faf6895a6 in ap_process_http_connection ()
#9  0x0000558faf67b78b in ap_run_process_connection ()
#10 0x0000558faf67be79 in ap_process_connection ()
#11 0x00007f0dab9e195b in child_main () from /usr/local/apache2/modules/mod_mpm_prefork.so
#12 0x00007f0dab9e1bee in make_child () from /usr/local/apache2/modules/mod_mpm_prefork.so
#13 0x00007f0dab9e1c55 in startup_children () from /usr/local/apache2/modules/mod_mpm_prefork.so
#14 0x00007f0dab9e2319 in prefork_run () from /usr/local/apache2/modules/mod_mpm_prefork.so
#15 0x0000558faf63dde8 in ap_run_mpm ()
#16 0x0000558faf6337ef in main ()
```
