### PR TITLE
Add required scope when passing a Request Object

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -97,3 +97,4 @@ reporting bugs, providing fixes, suggesting useful features or other:
 	tarteens <https://github.com/tarteens>
 	Atzm WATANABE <https://github.com/atzm>
 	Rui Ventura <https://github.com/rgcv>
+	Philip Brusten <https://github.com/gueuselambix>

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+04/24/2026
+- oidc: add scope=openid to authorization request when passing a Request Object
+by Reference (request_uri) as defined by the OIDC spec. See #1385; thanks @gueuselambix, @hjmikkon
+
 04/18/2026
 - build: conditionally add --coverage to AM_LDFLAGS in Makefile.am
 

--- a/src/proto/request.c
+++ b/src/proto/request.c
@@ -128,6 +128,7 @@ static int oidc_proto_request_auth_push(request_rec *r, struct oidc_provider_t *
 	apr_table_clear(params);
 	apr_table_setn(params, OIDC_PROTO_CLIENT_ID, oidc_cfg_provider_client_id_get(provider));
 	apr_table_setn(params, OIDC_PROTO_REQUEST_URI, request_uri);
+	apr_table_setn(params, OIDC_PROTO_SCOPE, OIDC_PROTO_SCOPE_OPENID);
 	authorization_request =
 	    oidc_http_query_encoded_url(r, oidc_cfg_provider_authorization_endpoint_url_get(provider), params);
 	oidc_http_hdr_out_location_set(r, authorization_request);


### PR DESCRIPTION
According to the [OpenID Connect Core 1.0 incorporating errata set 2](https://openid.net/specs/openid-connect-core-1_0.html) the client should pass the `scope=openid` parameter when sending the `request_uri` (e.g. after sending a PAR)

> Even if a scope parameter is present in the referenced Request Object, a scope parameter MUST always be passed using the OAuth 2.0 request syntax containing the openid scope value to indicate to the underlying OAuth 2.0 logic that this is an OpenID Connect request.