### PR TITLE
fix: verify refreshed id_token signature before storing claims in session

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -98,3 +98,4 @@ reporting bugs, providing fixes, suggesting useful features or other:
 	Atzm WATANABE <https://github.com/atzm>
 	Rui Ventura <https://github.com/rgcv>
 	Philip Brusten <https://github.com/gueuselambix>
+	Sun Liqiang <https://github.com/Pyolar>

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,10 +1,18 @@
 07/31/2026
-- refresh: verify the JWS signature on a refreshed id_token before storing its
-  claims in the session. oidc_refresh_token_grant_apply_id_token parsed the
-  id_token from the token endpoint with oidc_jwt_parse, which decrypts but does
-  not validate the signature, so an operator that returned an unsigned "alg":"none"
-  id_token (or a token signed with an untrusted key) could inject arbitrary claims
-  into the session
+- refresh: validate a refreshed id_token before applying it to the session.
+  oidc_refresh_token_grant_apply_id_token took the id_token returned by the token
+  endpoint apart with a bare oidc_jwt_parse and stored its claims unconditionally:
+  no decryption keys, no signature verification and none of the payload checks. It
+  now runs the same oidc_proto_idtoken_parse as the id_token obtained at
+  authentication time, as OpenID Connect Core 1.0 section 12.2 requires - keeping
+  the section 3.1.3.7 item 6 exception for an unsigned id_token received over the
+  TLS-protected back-channel, which a refresh response is - and additionally
+  refuses a refreshed id_token whose "sub" differs from the one the session was
+  established with. An id_token that does not validate no longer contributes its
+  claims, is no longer stored in its serialized form and is no longer handed back
+  to the caller; the refresh grant itself still succeeds, so the refreshed access
+  token is unaffected. Thanks to Sun Liqiang for reporting the missing signature
+  verification
 
 07/30/2026
 - metadata: report an "mtls_endpoint_aliases" entry that is not a valid URL as

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+07/31/2026
+- refresh: verify the JWS signature on a refreshed id_token before storing its
+  claims in the session. oidc_refresh_token_grant_apply_id_token parsed the
+  id_token from the token endpoint with oidc_jwt_parse, which decrypts but does
+  not validate the signature, so an operator that returned an unsigned "alg":"none"
+  id_token (or a token signed with an untrusted key) could inject arbitrary claims
+  into the session
+
 07/30/2026
 - metadata: report an "mtls_endpoint_aliases" entry that is not a valid URL as
   an error instead of quietly using the conventional endpoint for it. RFC 8705

--- a/src/handle/refresh.c
+++ b/src/handle/refresh.c
@@ -306,58 +306,86 @@ static apr_byte_t oidc_refresh_token_grant_obtain_tokens(request_rec *r, oidc_cf
 }
 
 /*
- * apply a refreshed id_token to the session: optionally persist the
- * serialized form, parse it, store its claims, update the session expiry
- * when no fixed max-duration is configured and return it to the caller
+ * OpenID Connect Core 1.0 section 12.2 requires the "sub" claim in an id_token obtained from a
+ * refresh grant to represent the same end-user as the one in the id_token that was issued at
+ * authentication time: refuse a refreshed id_token that would silently move an established
+ * session to a different subject. When no earlier claims are on record - the session was
+ * established without an id_token, or storing its claims was turned off - there is nothing to
+ * compare against and the check does not apply
  */
-static void oidc_refresh_token_grant_apply_id_token(request_rec *r, const oidc_cfg_t *c, oidc_session_t *session,
+static apr_byte_t oidc_refresh_token_grant_id_token_sub_match(request_rec *r, const oidc_session_t *session,
+							      const oidc_jwt_t *jwt) {
+
+	const oidc_json_t *claims = oidc_session_get_idtoken_claims(r, session);
+	const char *sub =
+	    (claims != NULL) ? oidc_json_string_value(oidc_json_object_get(claims, OIDC_CLAIM_SUB)) : NULL;
+
+	if (sub == NULL)
+		return TRUE;
+
+	if (_oidc_strcmp(sub, jwt->payload.sub) != 0) {
+		oidc_error(r,
+			   "the \"%s\" claim (%s) in the refreshed id_token differs from the one established for this "
+			   "session (%s): rejecting the refreshed id_token",
+			   OIDC_CLAIM_SUB, jwt->payload.sub, sub);
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+/*
+ * apply a refreshed id_token to the session: validate it, store its claims and
+ * optionally its serialized form, update the session expiry when no fixed
+ * max-duration is configured and return it to the caller
+ */
+static void oidc_refresh_token_grant_apply_id_token(request_rec *r, oidc_cfg_t *c, oidc_session_t *session,
 						    const oidc_provider_t *provider, char *s_id_token,
 						    char **new_id_token) {
 
 	oidc_jwt_t *id_token_jwt = NULL;
-	oidc_jose_error_t err;
-	oidc_jwk_t *jwk = NULL;
+
+	/*
+	 * validate the refreshed id_token just like the one obtained at authentication time: section 12.2 of
+	 * OpenID Connect Core 1.0 requires it to be validated according to section 3.1.3.7, which is what
+	 * oidc_proto_idtoken_parse implements - decryption, signature verification and the "iss"/"aud"/"azp"/
+	 * "exp"/"iat" payload checks - including the exception that section 3.1.3.7 item 6 makes for an
+	 * unsigned id_token obtained over the TLS-protected back-channel; a refresh response is such a
+	 * back-channel response, hence is_code_flow=TRUE. There is no nonce to check here: the nonce belongs
+	 * to the authentication request, not to a refresh
+	 */
+	if (oidc_proto_idtoken_parse(r, c, provider, s_id_token, NULL, &id_token_jwt, TRUE) == FALSE) {
+		oidc_warn(r, "refreshed id_token could not be validated, retaining the claims obtained earlier");
+		return;
+	}
+
+	if (oidc_refresh_token_grant_id_token_sub_match(r, session, id_token_jwt) == FALSE) {
+		oidc_jwt_destroy(id_token_jwt);
+		return;
+	}
 
 	/* only store the serialized representation when configured so */
 	if (oidc_cfg_store_id_token_get(c))
 		oidc_session_set_idtoken(r, session, s_id_token);
 
-	if (oidc_jwt_parse(r->pool, s_id_token, &id_token_jwt, NULL, FALSE, &err) == FALSE) {
-		oidc_warn(r, "parsing of id_token failed");
-	} else if (oidc_util_key_symmetric_create(r, oidc_cfg_provider_client_secret_get(provider), 0, NULL, TRUE,
-						  &jwk) == FALSE) {
-		oidc_warn(r, "could not create symmetric key for refreshed id_token signature validation");
-	} else if (oidc_proto_jwt_verify(r, (oidc_cfg_t *)c, id_token_jwt, oidc_cfg_provider_jwks_uri_get(provider),
-					 oidc_cfg_provider_ssl_validate_server_get(provider),
-					 oidc_util_key_symmetric_merge(r->pool,
-								       oidc_cfg_provider_verify_public_keys_get(provider),
-								       jwk),
-					 oidc_cfg_provider_id_token_signed_response_alg_get(provider)) == FALSE) {
-		oidc_warn(r,
-			  "refreshed id_token signature could not be validated, discarding the id_token");
-	} else {
-		/* store the claims payload in the id_token for later reference */
-		oidc_session_set_idtoken_claims(r, session, id_token_jwt->payload.value.json);
+	/* store the claims payload in the id_token for later reference */
+	oidc_session_set_idtoken_claims(r, session, id_token_jwt->payload.value.json);
 
-		if (oidc_cfg_provider_session_max_duration_get(provider) == 0) {
-			/* update the session expiry to match the expiry of the id_token
-			 * NB: "exp" is a JSON number, so clamp rather than wrap on a far-future value */
-			apr_time_t session_expires = oidc_util_apr_time_from_sec(id_token_jwt->payload.exp);
-			oidc_session_set_session_expires(r, session, session_expires);
+	if (oidc_cfg_provider_session_max_duration_get(provider) == 0) {
+		/* update the session expiry to match the expiry of the id_token
+		 * NB: "exp" is a JSON number, so clamp rather than wrap on a far-future value */
+		apr_time_t session_expires = oidc_util_apr_time_from_sec(id_token_jwt->payload.exp);
+		oidc_session_set_session_expires(r, session, session_expires);
 
-			/* log message about the updated max session duration */
-			oidc_log_session_expires(r, "session max lifetime", session_expires);
-		}
-
-		/* see if we need to return it as a parameter */
-		if (new_id_token != NULL)
-			*new_id_token = s_id_token;
+		/* log message about the updated max session duration */
+		oidc_log_session_expires(r, "session max lifetime", session_expires);
 	}
 
-	if (jwk)
-		oidc_jwk_destroy(jwk);
-	if (id_token_jwt != NULL)
-		oidc_jwt_destroy(id_token_jwt);
+	/* see if we need to return it as a parameter */
+	if (new_id_token != NULL)
+		*new_id_token = s_id_token;
+
+	oidc_jwt_destroy(id_token_jwt);
 }
 
 /*

--- a/src/handle/refresh.c
+++ b/src/handle/refresh.c
@@ -316,6 +316,7 @@ static void oidc_refresh_token_grant_apply_id_token(request_rec *r, const oidc_c
 
 	oidc_jwt_t *id_token_jwt = NULL;
 	oidc_jose_error_t err;
+	oidc_jwk_t *jwk = NULL;
 
 	/* only store the serialized representation when configured so */
 	if (oidc_cfg_store_id_token_get(c))
@@ -323,6 +324,17 @@ static void oidc_refresh_token_grant_apply_id_token(request_rec *r, const oidc_c
 
 	if (oidc_jwt_parse(r->pool, s_id_token, &id_token_jwt, NULL, FALSE, &err) == FALSE) {
 		oidc_warn(r, "parsing of id_token failed");
+	} else if (oidc_util_key_symmetric_create(r, oidc_cfg_provider_client_secret_get(provider), 0, NULL, TRUE,
+						  &jwk) == FALSE) {
+		oidc_warn(r, "could not create symmetric key for refreshed id_token signature validation");
+	} else if (oidc_proto_jwt_verify(r, (oidc_cfg_t *)c, id_token_jwt, oidc_cfg_provider_jwks_uri_get(provider),
+					 oidc_cfg_provider_ssl_validate_server_get(provider),
+					 oidc_util_key_symmetric_merge(r->pool,
+								       oidc_cfg_provider_verify_public_keys_get(provider),
+								       jwk),
+					 oidc_cfg_provider_id_token_signed_response_alg_get(provider)) == FALSE) {
+		oidc_warn(r,
+			  "refreshed id_token signature could not be validated, discarding the id_token");
 	} else {
 		/* store the claims payload in the id_token for later reference */
 		oidc_session_set_idtoken_claims(r, session, id_token_jwt->payload.value.json);
@@ -342,6 +354,8 @@ static void oidc_refresh_token_grant_apply_id_token(request_rec *r, const oidc_c
 			*new_id_token = s_id_token;
 	}
 
+	if (jwk)
+		oidc_jwk_destroy(jwk);
 	if (id_token_jwt != NULL)
 		oidc_jwt_destroy(id_token_jwt);
 }

--- a/test/test_handle.c
+++ b/test/test_handle.c
@@ -655,10 +655,13 @@ START_TEST(test_handle_refresh_grant_cached_results_clamps_and_id_token) {
 	oidc_session_load(r, &session);
 
 	/* a cached grant result with an out-of-int-range expires_in must be clamped, and with
-	 * session_max_duration == 0 a valid cached id_token updates the session expiry */
+	 * session_max_duration == 0 a valid cached id_token updates the session expiry; "valid"
+	 * includes verifiable, so the provider is configured with the key it was signed with */
 	oidc_cfg_provider_session_max_duration_set(r->pool, provider, 0);
-	char *id_token = e2e_sign_idtoken_hs256(r, "https://idp.example.com", "client_id", "alice", "nonce-cr1",
-						"cached-idtoken-secret-long-enough");
+	const char *secret = "cached-idtoken-secret-long-enough";
+	oidc_cfg_provider_client_secret_set(r->pool, provider, secret);
+	char *id_token =
+	    e2e_sign_idtoken_hs256(r, "https://idp.example.com", "client_id", "alice", "nonce-cr1", secret);
 	char *s_json = apr_psprintf(r->pool,
 				    "{\"access_token\":\"AT-CACHED\",\"token_type\":\"Bearer\","
 				    "\"expires_in\":9999999999999,\"id_token\":\"%s\","
@@ -683,6 +686,162 @@ START_TEST(test_handle_refresh_grant_cached_results_clamps_and_id_token) {
 	new_at = NULL;
 	ck_assert_int_eq(oidc_refresh_token_grant(r, c, session, provider, &new_at, NULL, NULL), TRUE);
 	ck_assert_str_eq(new_at, "AT-CACHED-2");
+
+	oidc_session_free(r, session);
+}
+END_TEST
+
+/* seed the refresh-token cache with a grant result carrying `id_token`, so that
+ * oidc_refresh_token_grant applies that id_token without contacting the OP */
+static void e2e_refresh_cache_seed(request_rec *r, oidc_session_t *session, const char *rt, const char *id_token) {
+	char *s_json = apr_psprintf(r->pool,
+				    "{\"access_token\":\"AT-%s\",\"token_type\":\"Bearer\",\"expires_in\":3600,"
+				    "\"id_token\":\"%s\",\"refresh_token\":\"%s-next\",\"ts\":%" APR_TIME_T_FMT "}",
+				    rt, id_token, rt, apr_time_sec(apr_time_now()));
+	oidc_session_set_refresh_token(r, session, rt);
+	oidc_cache_set_refresh_token(r, rt, s_json, apr_time_now() + apr_time_from_sec(30));
+}
+
+/* a refreshed id_token whose signature verifies against the provider's key is applied:
+ * its claims and its serialized form go into the session and it is handed back to the caller */
+START_TEST(test_handle_refresh_grant_id_token_validated) {
+	request_rec *r = oidc_test_request_get();
+	oidc_cfg_t *c = oidc_test_cfg_get();
+	oidc_provider_t *provider = oidc_cfg_provider_get(c);
+	oidc_session_t *session = NULL;
+	oidc_session_load(r, &session);
+
+	const char *secret = "refresh-idtoken-secret-long-enough";
+	oidc_cfg_provider_client_secret_set(r->pool, provider, secret);
+
+	char *id_token = e2e_sign_idtoken_hs256(r, "https://idp.example.com", "client_id", "alice", "nonce-rv", secret);
+	e2e_refresh_cache_seed(r, session, "RT-IDT-OK", id_token);
+
+	char *new_idt = NULL;
+	ck_assert_int_eq(oidc_refresh_token_grant(r, c, session, provider, NULL, NULL, &new_idt), TRUE);
+	ck_assert_ptr_nonnull(new_idt);
+	ck_assert_str_eq(new_idt, id_token);
+
+	const oidc_json_t *claims = oidc_session_get_idtoken_claims(r, session);
+	ck_assert_ptr_nonnull(claims);
+	ck_assert_str_eq(oidc_json_string_value(oidc_json_object_get(claims, OIDC_CLAIM_SUB)), "alice");
+	/* store_id_token defaults to on, so the serialized form is persisted too */
+	ck_assert_str_eq(oidc_session_get_idtoken(r, session), id_token);
+
+	oidc_session_free(r, session);
+}
+END_TEST
+
+/* a refreshed id_token that does not verify contributes nothing: not its claims, not its
+ * serialized form, and it is not handed back as the caller's new id_token. The grant itself
+ * still succeeds - the refreshed access token is unaffected by a bad id_token */
+START_TEST(test_handle_refresh_grant_id_token_bad_signature) {
+	request_rec *r = oidc_test_request_get();
+	oidc_cfg_t *c = oidc_test_cfg_get();
+	oidc_provider_t *provider = oidc_cfg_provider_get(c);
+	oidc_session_t *session = NULL;
+	oidc_session_load(r, &session);
+
+	oidc_cfg_provider_client_secret_set(r->pool, provider, "refresh-idtoken-secret-long-enough");
+
+	/* signed with a key the provider is not configured with */
+	char *id_token = e2e_sign_idtoken_hs256(r, "https://idp.example.com", "client_id", "mallory", "nonce-rb",
+						"an-entirely-different-secret-key1");
+	e2e_refresh_cache_seed(r, session, "RT-IDT-BADSIG", id_token);
+
+	char *new_at = NULL, *new_idt = NULL;
+	ck_assert_int_eq(oidc_refresh_token_grant(r, c, session, provider, &new_at, NULL, &new_idt), TRUE);
+	ck_assert_str_eq(new_at, "AT-RT-IDT-BADSIG");
+
+	ck_assert_ptr_null(new_idt);
+	ck_assert_ptr_null(oidc_session_get_idtoken_claims(r, session));
+	ck_assert_ptr_null(oidc_session_get_idtoken(r, session));
+
+	oidc_session_free(r, session);
+}
+END_TEST
+
+/* OpenID Connect Core 1.0 section 12.2: a refreshed id_token must not move an established
+ * session to a different subject, however well signed it is */
+START_TEST(test_handle_refresh_grant_id_token_sub_mismatch) {
+	request_rec *r = oidc_test_request_get();
+	oidc_cfg_t *c = oidc_test_cfg_get();
+	oidc_provider_t *provider = oidc_cfg_provider_get(c);
+	oidc_session_t *session = NULL;
+	oidc_session_load(r, &session);
+
+	const char *secret = "refresh-idtoken-secret-long-enough";
+	oidc_cfg_provider_client_secret_set(r->pool, provider, secret);
+
+	/* the session was established for "alice" */
+	oidc_json_t *prior = oidc_json_object();
+	oidc_json_object_set_new(prior, OIDC_CLAIM_SUB, oidc_json_string("alice"));
+	oidc_session_set_idtoken_claims(r, session, prior);
+	oidc_json_decref(prior);
+
+	char *id_token =
+	    e2e_sign_idtoken_hs256(r, "https://idp.example.com", "client_id", "mallory", "nonce-rs", secret);
+	e2e_refresh_cache_seed(r, session, "RT-IDT-SUB", id_token);
+
+	char *new_idt = NULL;
+	ck_assert_int_eq(oidc_refresh_token_grant(r, c, session, provider, NULL, NULL, &new_idt), TRUE);
+	ck_assert_ptr_null(new_idt);
+
+	/* the claims established at authentication time are retained */
+	const oidc_json_t *claims = oidc_session_get_idtoken_claims(r, session);
+	ck_assert_ptr_nonnull(claims);
+	ck_assert_str_eq(oidc_json_string_value(oidc_json_object_get(claims, OIDC_CLAIM_SUB)), "alice");
+	ck_assert_ptr_null(oidc_session_get_idtoken(r, session));
+
+	/* the same subject refreshing is applied normally */
+	id_token = e2e_sign_idtoken_hs256(r, "https://idp.example.com", "client_id", "alice", "nonce-rs2", secret);
+	e2e_refresh_cache_seed(r, session, "RT-IDT-SUB-OK", id_token);
+	new_idt = NULL;
+	ck_assert_int_eq(oidc_refresh_token_grant(r, c, session, provider, NULL, NULL, &new_idt), TRUE);
+	ck_assert_str_eq(new_idt, id_token);
+
+	oidc_session_free(r, session);
+}
+END_TEST
+
+/* an OP that legitimately issues unsigned id_tokens keeps working across a refresh: section
+ * 3.1.3.7 item 6 lets the TLS-protected back-channel stand in for the signature check, and a
+ * refresh response is such a back-channel response */
+START_TEST(test_handle_refresh_grant_id_token_unsigned) {
+	request_rec *r = oidc_test_request_get();
+	oidc_cfg_t *c = oidc_test_cfg_get();
+	oidc_provider_t *provider = oidc_cfg_provider_get(c);
+	oidc_session_t *session = NULL;
+	oidc_session_load(r, &session);
+
+	oidc_jose_error_t err;
+	oidc_jwt_t *jwt = oidc_jwt_new(r->pool, TRUE, TRUE);
+	jwt->header.alg = apr_pstrdup(r->pool, "none");
+	apr_time_t now = apr_time_sec(apr_time_now());
+	oidc_json_object_set_new(jwt->payload.value.json, "iss", oidc_json_string("https://idp.example.com"));
+	oidc_json_object_set_new(jwt->payload.value.json, "aud", oidc_json_string("client_id"));
+	oidc_json_object_set_new(jwt->payload.value.json, OIDC_CLAIM_SUB, oidc_json_string("alice"));
+	oidc_json_object_set_new(jwt->payload.value.json, "iat", oidc_json_integer(now));
+	oidc_json_object_set_new(jwt->payload.value.json, "exp", oidc_json_integer(now + 600));
+	char *id_token = oidc_jose_jwt_serialize(r->pool, jwt, &err);
+	ck_assert_ptr_nonnull(id_token);
+	oidc_jwt_destroy(jwt);
+
+	e2e_refresh_cache_seed(r, session, "RT-IDT-NONE", id_token);
+
+	char *new_idt = NULL;
+	ck_assert_int_eq(oidc_refresh_token_grant(r, c, session, provider, NULL, NULL, &new_idt), TRUE);
+	ck_assert_str_eq(new_idt, id_token);
+	const oidc_json_t *claims = oidc_session_get_idtoken_claims(r, session);
+	ck_assert_ptr_nonnull(claims);
+	ck_assert_str_eq(oidc_json_string_value(oidc_json_object_get(claims, OIDC_CLAIM_SUB)), "alice");
+
+	/* ... but not when the operator has pinned a real signing algorithm */
+	ck_assert_ptr_null(oidc_cfg_provider_id_token_signed_response_alg_set(r->pool, provider, "RS256"));
+	e2e_refresh_cache_seed(r, session, "RT-IDT-NONE-PINNED", id_token);
+	new_idt = NULL;
+	ck_assert_int_eq(oidc_refresh_token_grant(r, c, session, provider, NULL, NULL, &new_idt), TRUE);
+	ck_assert_ptr_null(new_idt);
 
 	oidc_session_free(r, session);
 }
@@ -4715,6 +4874,10 @@ int main(void) {
 	tcase_add_test(refresh, test_handle_refresh_grant_cache_hit);
 	tcase_add_test(refresh, test_handle_refresh_grant_with_id_token);
 	tcase_add_test(refresh, test_handle_refresh_grant_cached_results_clamps_and_id_token);
+	tcase_add_test(refresh, test_handle_refresh_grant_id_token_validated);
+	tcase_add_test(refresh, test_handle_refresh_grant_id_token_bad_signature);
+	tcase_add_test(refresh, test_handle_refresh_grant_id_token_sub_mismatch);
+	tcase_add_test(refresh, test_handle_refresh_grant_id_token_unsigned);
 	tcase_add_test(refresh, test_handle_refresh_grant_cache_locks);
 	tcase_add_test(refresh, test_handle_refresh_before_expiry_due_paths);
 	tcase_add_test(refresh, test_handle_refresh_request_error_arms);


### PR DESCRIPTION
oidc_refresh_token_grant_apply_id_token calls oidc_jwt_parse to parse the id_token from a refresh grant response, but oidc_jwt_parse only decrypts — it never validates the JWS signature. If the token endpoint returns an unsigned or improperly signed id_token, the unverified claims are stored directly in the session.

This adds a oidc_proto_jwt_verify call (matching the pattern already used in oidc_proto_idtoken_parse) between parsing and storing, so a token that fails signature validation is discarded.