### PR TITLE
userinfo: verify the signature on JWT-encoded composite claims when verification keys are configured

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,12 @@
+08/03/2026
+- userinfo: validate the signature on JWT-encoded aggregated/distributed (composite)
+  claims returned in a UserInfo response against the statically configured verification
+  keys (OIDCProviderVerifyCertFiles). Composite-claims JWTs that fail signature validation
+  are discarded and their claims are not applied. Without configured verification keys the
+  composite-claims JWTs are applied as before, since OpenID Connect Core 1.0 section 5.6.2
+  does not require signature validation of these JWTs when the Claims Provider keys cannot
+  be obtained
+
 08/01/2026
 - release 2.4.20
 

--- a/src/proto/userinfo.c
+++ b/src/proto/userinfo.c
@@ -169,9 +169,37 @@ static const char *oidc_proto_userinfo_composite_source_payload(request_rec *r, 
 }
 
 /*
+ * verify the signature on a JWT from an aggregated/distributed claim source against the
+ * statically configured verification keys (OIDCProviderVerifyCertFiles); verification is
+ * opt-in: without configured keys the JWT is parsed and applied as before (the OIDC Core
+ * 1.0 section 5.6.2 JWT does not require signature validation unless the issuer's keys can
+ * be obtained, and the module has no other way to obtain them)
+ */
+static apr_byte_t oidc_proto_userinfo_composite_claim_verify(request_rec *r, oidc_cfg_t *cfg, oidc_jwt_t *jwt,
+							     const char *key) {
+	const oidc_provider_t *provider = oidc_cfg_provider_get(cfg);
+	const apr_array_header_t *verify_keys = oidc_cfg_provider_verify_public_keys_get(provider);
+	oidc_jwks_uri_t jwks_uri = {NULL, 0, NULL, NULL};
+
+	if (verify_keys == NULL)
+		return TRUE;
+
+	if (oidc_proto_jwt_verify(r, cfg, jwt, &jwks_uri, oidc_cfg_provider_ssl_validate_server_get(provider),
+				  oidc_util_key_symmetric_merge(r->pool, verify_keys, NULL), NULL) == FALSE) {
+		oidc_error(r,
+			   "signature on the JWT from aggregated/distributed claim source \"%s\" could not be "
+			   "validated against the statically configured verification keys, ignoring it",
+			   key);
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+/*
  * parse a single aggregated/distributed claim JWT and merge its payload into decoded[key]
  */
-static void oidc_proto_userinfo_composite_decode_source(request_rec *r, const oidc_cfg_t *cfg, const char *key,
+static void oidc_proto_userinfo_composite_decode_source(request_rec *r, oidc_cfg_t *cfg, const char *key,
 							const char *s_json, oidc_json_t *decoded) {
 	oidc_jose_error_t err;
 	oidc_jwt_t *jwt = NULL;
@@ -180,6 +208,8 @@ static void oidc_proto_userinfo_composite_decode_source(request_rec *r, const oi
 			   oidc_util_key_symmetric_merge(r->pool, oidc_cfg_private_keys_get(cfg), NULL), FALSE,
 			   &err) == FALSE) {
 		oidc_error(r, "could not parse JWT from aggregated claim \"%s\": %s", key, oidc_jose_e2s(r->pool, err));
+	} else if (oidc_proto_userinfo_composite_claim_verify(r, cfg, jwt, key) == FALSE) {
+		oidc_error(r, "could not validate JWT from aggregated claim \"%s\", ignoring it", key);
 	} else {
 		oidc_json_t *v = oidc_json_object_get(decoded, key);
 		if (v == NULL) {

--- a/test/test_proto.c
+++ b/test/test_proto.c
@@ -2306,6 +2306,86 @@ START_TEST(test_proto_userinfo_request_composite_claims) {
 }
 END_TEST
 
+/* with OIDCProviderVerifyCertFiles configured, a composite-claims JWT that verifies
+ * against the configured key is applied, and one that does not is discarded */
+START_TEST(test_proto_userinfo_request_composite_claims_verify_keys) {
+	request_rec *r = oidc_test_request_get();
+	oidc_cfg_t *c = oidc_test_cfg_get();
+	oidc_provider_t *provider = oidc_cfg_provider_get(c);
+	oidc_jose_error_t err;
+
+	/* load test/private.pem so we can sign with the RSA key that matches test/public.pem */
+	const char *dir = getenv("srcdir") ? getenv("srcdir") : ".";
+	cmd_parms *cmd = oidc_test_cmd_get(OIDCPrivateKeyFiles);
+	const char *err2 = oidc_cmd_private_keys_set(
+	    cmd, NULL, apr_pstrdup(r->pool, apr_psprintf(r->pool, "rsa-1#%s/private.pem", dir)));
+	ck_assert_msg(err2 == NULL, "could not load private key: %s", err2);
+	oidc_jwk_t *sign_jwk = oidc_util_key_list_first(oidc_cfg_private_keys_get(c), -1, NULL);
+	ck_assert_ptr_nonnull(sign_jwk);
+
+	/* configure the matching public key as a static verification key */
+	cmd = oidc_test_cmd_get(OIDCProviderVerifyCertFiles);
+	ck_assert_ptr_null(oidc_cmd_provider_verify_public_keys_set(
+	    cmd, NULL, apr_psprintf(r->pool, "rsa-1#%s/public.pem", dir)));
+
+	/* aggregated claim JWT that verifies against the configured key */
+	oidc_jwt_t *jwt = oidc_jwt_new(r->pool, TRUE, TRUE);
+	jwt->header.alg = apr_pstrdup(r->pool, "RS256");
+	jwt->header.kid = apr_pstrdup(r->pool, "rsa-1");
+	oidc_json_object_set_new(jwt->payload.value.json, "credit_score", oidc_json_integer(700));
+	ck_assert_int_eq(oidc_jwt_sign(r->pool, jwt, sign_jwk, FALSE, &err), TRUE);
+	char *src1_jwt = oidc_jose_jwt_serialize(r->pool, jwt, &err);
+	oidc_jwt_destroy(jwt);
+	ck_assert_ptr_nonnull(src1_jwt);
+
+	/* aggregated claim JWT signed with an unknown key: parses but must not verify */
+	oidc_jwk_t *bad_jwk = NULL;
+	ck_assert_int_eq(oidc_util_key_symmetric_create(r, "0123456789abcdef0123456789abcdef", 0, NULL, FALSE,
+							&bad_jwk),
+			 TRUE);
+	jwt = oidc_jwt_new(r->pool, TRUE, TRUE);
+	jwt->header.alg = apr_pstrdup(r->pool, "HS256");
+	jwt->header.kid = apr_pstrdup(r->pool, "bogus");
+	oidc_json_object_set_new(jwt->payload.value.json, "shoe_size", oidc_json_integer(42));
+	ck_assert_int_eq(oidc_jwt_sign(r->pool, jwt, bad_jwk, FALSE, &err), TRUE);
+	char *src2_jwt = oidc_jose_jwt_serialize(r->pool, jwt, &err);
+	oidc_jwk_destroy(bad_jwk);
+	oidc_jwt_destroy(jwt);
+	ck_assert_ptr_nonnull(src2_jwt);
+
+	/* userinfo response with one source that verifies and one that does not */
+	const char *userinfo_body = apr_psprintf(r->pool,
+						 "{\"sub\":\"alice\","
+						 "\"_claim_names\":{\"credit_score\":\"src1\",\"shoe_size\":\"src2\"},"
+						 "\"_claim_sources\":{\"src1\":{\"JWT\":\"%s\"},"
+						 "\"src2\":{\"JWT\":\"%s\"}}}",
+						 src1_jwt, src2_jwt);
+	oidc_test_http_response_t resp = {
+	    .status_code = 200, .content_type = "application/json", .body = userinfo_body};
+	oidc_test_http_server_t *srv = oidc_test_http_server_start(r->pool, &resp);
+	ck_assert_ptr_nonnull(srv);
+	oidc_cfg_provider_userinfo_endpoint_url_set(r->pool, provider, oidc_test_http_server_url(srv, r->pool));
+	oidc_cfg_provider_ssl_validate_server_set(r->pool, provider, 0);
+
+	char *s_userinfo = NULL, *userinfo_jwt = NULL;
+	oidc_json_t *userinfo_claims = NULL;
+	long response_code = 0;
+	ck_assert_int_eq(oidc_proto_userinfo_request(r, c, provider, "alice", "AT", "Bearer", &s_userinfo,
+						     &userinfo_jwt, &userinfo_claims, &response_code),
+			 TRUE);
+	ck_assert_ptr_nonnull(userinfo_claims);
+	/* the verified JWT is applied, the one with an unverifiable signature is discarded */
+	ck_assert_int_eq((int)oidc_json_integer_value(oidc_json_object_get(userinfo_claims, "credit_score")), 700);
+	ck_assert_ptr_null(oidc_json_object_get(userinfo_claims, "shoe_size"));
+	ck_assert_ptr_null(oidc_json_object_get(userinfo_claims, "_claim_names"));
+	ck_assert_ptr_null(oidc_json_object_get(userinfo_claims, "_claim_sources"));
+
+	(void)oidc_test_http_server_wait(srv);
+	oidc_test_http_server_stop(srv);
+	oidc_json_decref(userinfo_claims);
+}
+END_TEST
+
 /* a DPoP-bound access token makes the userinfo request carry a DPoP proof */
 START_TEST(test_proto_userinfo_request_dpop) {
 	request_rec *r = oidc_test_request_get();
@@ -3508,6 +3588,7 @@ int main(void) {
 	tcase_add_test(e2e, test_proto_response_idtoken_token_happy);
 	tcase_add_test(e2e, test_proto_response_type_mismatch);
 	tcase_add_test(e2e, test_proto_userinfo_request_composite_claims);
+	tcase_add_test(e2e, test_proto_userinfo_request_composite_claims_verify_keys);
 	tcase_add_test(e2e, test_proto_userinfo_request_dpop);
 	tcase_add_test(e2e, test_proto_userinfo_request_success);
 	tcase_add_test(e2e, test_proto_userinfo_request_sub_mismatch);


### PR DESCRIPTION
oidc_proto_userinfo_composite_decode_source took the JWT from an aggregated/distributed (composite) claim source apart with a bare oidc_jwt_parse and merged its payload into the userinfo claims unconditionally, without any signature verification.

With this change, when static verification keys are configured (OIDCProviderVerifyCertFiles), the composite-claims JWT is signature validated against them first, and one that fails validation is discarded - its claims are not applied. Without configured verification keys the previous behavior is preserved, since OIDC Core 1.0 section 5.6.2 does not require signature validation of these JWTs when the Claims Provider keys cannot be obtained.